### PR TITLE
Incorrect table name in generated migration

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -1,6 +1,6 @@
 class DeviseUidAddTo<%= table_name.camelize %> < ActiveRecord::Migration
   def change
-    add_column :users, :uid, :string
-    add_index :users, :uid, :unique => true
+    add_column :<%= table_name %>, :uid, :string
+    add_index :<%= table_name %>, :uid, :unique => true
   end
 end


### PR DESCRIPTION
After running the generator:
`rails generate devise_uid DeviceUser`  (the model represents users of electronic devices )

``` ruby
class DeviseUidAddToDeviceUsers < ActiveRecord::Migration
  def change
    add_column :users, :uid, :string
    add_index :users, :uid, :unique => true
  end
end
```

the generated file references the _users_ table and not _device__users_ for the add_column and add_index lines.
