### PR TITLE
Preventing Standard Error

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -1,4 +1,4 @@
-class DeviseUidAddTo<%= table_name.camelize %> < ActiveRecord::Migration[7.0]
+class DeviseUidAddTo<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_version %>
   def change
     add_column :<%= table_name %>, :uid, :string
     add_index :<%= table_name %>, :uid, :unique => true

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -1,4 +1,4 @@
-class DeviseUidAddTo<%= table_name.camelize %> < ActiveRecord::Migration
+class DeviseUidAddTo<%= table_name.camelize %> < ActiveRecord::Migration[7.0]
   def change
     add_column :<%= table_name %>, :uid, :string
     add_index :<%= table_name %>, :uid, :unique => true


### PR DESCRIPTION
Directly inheriting from ActiveRecord::Migration is not supported, So it is required to specify that.